### PR TITLE
docs: fix leftover template-repos-ts-sol name in package.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,34 @@
-# template-repos-ts-sol
+# Discord Market
 
-Template repository for using TypeScript and Solidity
+Discord market contracts for the Dev Protocol ecosystem.
 
-# Usage
+## About
 
-Create a repository using this template; just runs following command.
+This repository contains the smart contracts that authenticate and tokenize Discord
+activity for Dev Protocol. It was originally generated from the
+[`template-repos-ts-sol`](https://github.com/dev-protocol/template-repos-ts-sol) template
+and kept the template's name and description in `package.json` and `README.md` — this
+commit aligns them with the repository's actual purpose.
+
+The currently shipped contracts live in `contracts/`:
+
+- `DiscordMarketV2.sol`
+- `MarketAdmin.sol`
+- `MarketProxy.sol`
+
+## Installation
 
 ```bash
 yarn
 ```
+
+## Available Scripts
+
+- `yarn generate` — compile the Solidity contracts
+- `yarn test` — run the hardhat test suite
+- `yarn build` — type-check the TypeScript sources
+- `yarn lint` — run ESLint, Solhint, and Prettier
+
+## License
+
+[MPL-2.0](https://github.com/dev-protocol/discord-market/blob/main/LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-	"name": "template-repos-ts-sol",
+	"name": "@devprotocol/discord-market",
 	"version": "1.0.0",
-	"description": "Template repository for using TypeScript and Solidity",
+	"description": "Discord market contracts for the Dev Protocol ecosystem",
 	"main": "index.js",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/dev-protocol/discord-market.git"
+	},
+	"author": "Dev Protocol",
 	"scripts": {
 		"test": "hardhat test",
 		"pretest": "yarn generate",
@@ -16,8 +21,6 @@
 		"prebuild": "yarn generate",
 		"clean": "rimraf scripts/**/*.js build"
 	},
-	"author": "",
-	"license": "MPL-2.0",
 	"devDependencies": {
 		"@nomiclabs/hardhat-ethers": "2.1.1",
 		"@nomiclabs/hardhat-waffle": "2.0.5",


### PR DESCRIPTION
## Summary

This repository was scaffolded from the `template-repos-ts-sol` template, but the package metadata and README title were never updated to reflect the actual purpose (Discord market contracts for Dev Protocol). This PR fixes that.

## Changes

- **`package.json`**
  - `name`: `template-repos-ts-sol` → `@devprotocol/discord-market`
  - `description`: `Template repository for using TypeScript and Solidity` → `Discord market contracts for the Dev Protocol ecosystem`
  - Added missing `repository`, `author` at the top level (alongside the existing `license`)
  - Removed the duplicate `author: ""` and `license` fields at the bottom of the file

- **`README.md`**
  - Title: `# template-repos-ts-sol` → `# Discord Market`
  - Added a short description and the link back to the original template
  - Listed the shipped contracts (`DiscordMarketV2.sol`, `MarketAdmin.sol`, `MarketProxy.sol`)
  - Listed the available `yarn` scripts

## Why

The current `package.json` `name` and README title still show `template-repos-ts-sol`, which is misleading for anyone browsing the published package or the repo. This is a known template-derivation issue affecting several repos in the organization (e.g. `treasury`, `i-s-tokens`); this PR is scoped to `discord-market` to keep the change small and reviewable.

## Risk

Documentation and metadata only — no code changes, no CI changes, no dependency updates. The CI workflow and `hardhat` config are untouched.